### PR TITLE
This handles datasource templates in the new xml-bad style of generating xml.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -36,7 +36,7 @@ options = dict(name='cascadenik',
         'Topic :: Internet :: WWW/HTTP :: Dynamic Content',
         'Topic :: Utilities'
         ],
-        scripts=['cascadenik-compile.py','cascadenik-style.py'],
+        scripts=['cascadenik-compile.py','cascadenik-style.py', 'cascadenik-extract-dscfg.py'],
         packages=['cascadenik'],
         )
 


### PR DESCRIPTION
The feature is generally this: http://trac.mapnik.org/changeset/574

However, the templates aren't attached to the map itself - just the map_parser.  This means we need to fully expand datasources relative to their templates before attempting to attach them to a map object.
