### PR TITLE
Don't scale opacity properties for retina

### DIFF
--- a/cascadenik/style.py
+++ b/cascadenik/style.py
@@ -369,7 +369,9 @@ class Declaration:
     
     def scaleBy(self, scale):
         self.selector = self.selector.scaledBy(scale)
-        self.value = self.value.scaledBy(scale)
+        
+        if not self.property.name.endswith('-opacity'):
+            self.value = self.value.scaledBy(scale)
 
 class Selector:
     """ Represents a complete selector with elements and attribute checks.


### PR DESCRIPTION
when using the --2x flag in cascadenik-compile to scale features for retina, we shouldn't be scaling the opacity values.

this pull request skips scaling for property names ending in '-opacity'
