### PR TITLE
Scale properties of type numbers for retina

### DIFF
--- a/cascadenik/style.py
+++ b/cascadenik/style.py
@@ -805,6 +805,8 @@ class Value:
     
         if type(scaled.value) in (int, float):
             scaled.value *= scale
+        elif isinstance(scaled.value, numbers):
+            scaled.value.values = (v * scale for v in scaled.value.values)
         
         return scaled
     


### PR DESCRIPTION
Only values of type int and float are scaled when compiling for retina (--2x flag)

The dasharray property is a `numbers` class, containing ints/floats, which should be scaled as ints and floats are.

This pull request modifies the `Value` class to scale `numbers` values.
