### PR TITLE
fix dash array retina scaling when numbers are same value

### DIFF
--- a/cascadenik/style.py
+++ b/cascadenik/style.py
@@ -808,8 +808,8 @@ class Value:
         if type(scaled.value) in (int, float):
             scaled.value *= scale
         elif isinstance(scaled.value, numbers):
-            scaled.value.values = (v * scale for v in scaled.value.values)
-        
+            scaled.value.values = tuple(v * scale for v in scaled.value.values)
+
         return scaled
     
     def __repr__(self):


### PR DESCRIPTION
When the values of a `numbers` object were different, scaling worked fine.  However when the values were the same, the declaration was getting dropped during compilation when scaled for retina (--2x)

ex.

```
dasharray: 2, 5;  <- worked
dasharray: 2, 2;  <- dropped
```

I'm not really clear why it was behaving this way, but the fix is to convert the `values` property of a `numbers` object back to a tuple after scaling, where previously it was a list after scaling.
