### PR TITLE
Remove text-force-odd-labels

### DIFF
--- a/cascadenik/compile.py
+++ b/cascadenik/compile.py
@@ -974,7 +974,6 @@ def get_text_rule_groups(declarations):
                     'text-face-name': 'face_name',
                     'text-fill': 'fill',
                     'text-fontset': 'fontset',
-                    'text-force-odd-labels': 'force_odd_labels',
                     'text-halo-fill': 'halo_fill',
                     'text-halo-radius': 'halo_radius',
                     'text-justify-align': 'justify_alignment',
@@ -1044,7 +1043,6 @@ def get_text_rule_groups(declarations):
             horizontal_alignment = values.has_key('text-horizontal-align') and values['text-horizontal-align'].value or None
             vertical_alignment = values.has_key('text-vertical-align') and values['text-vertical-align'].value or None
             justify_alignment = values.has_key('text-justify-align') and values['text-justify-align'].value or None
-            force_odd_labels = values.has_key('text-force-odd-labels') and values['text-force-odd-labels'].value or None
             line_spacing = values.has_key('text-line-spacing') and values['text-line-spacing'].value or None
             character_spacing = values.has_key('text-character-spacing') and values['text-character-spacing'].value or None
             
@@ -1055,7 +1053,7 @@ def get_text_rule_groups(declarations):
                                               avoid_edges, minimum_distance, allow_overlap, label_placement, \
                                               line_spacing, character_spacing, text_transform, fontset,
                                               anchor_dx, anchor_dy,horizontal_alignment, \
-                                              vertical_alignment, justify_alignment, force_odd_labels)
+                                              vertical_alignment, justify_alignment)
             
                 rules.append(make_rule(filter, symbolizer))
         

--- a/cascadenik/output.py
+++ b/cascadenik/output.py
@@ -283,7 +283,7 @@ class TextSymbolizer:
         minimum_distance=None, allow_overlap=None, label_placement=None, \
         character_spacing=None, line_spacing=None, text_transform=None, fontset=None, \
         anchor_dx=None, anchor_dy=None,horizontal_alignment=None,vertical_alignment=None,
-        justify_alignment=None, force_odd_labels=None):
+        justify_alignment=None):
 
         assert isinstance(name, basestring)
         assert face_name is None or face_name.__class__ is style.strings
@@ -332,7 +332,6 @@ class TextSymbolizer:
         self.vertical_alignment = vertical_alignment
         self.justify_alignment = justify_alignment
         self.horizontal_alignment = horizontal_alignment
-        self.force_odd_labels = force_odd_labels
         self.anchor_dx = anchor_dx
         self.anchor_dy = anchor_dy
 
@@ -393,7 +392,6 @@ class TextSymbolizer:
             sym.format.line_spacing = self.line_spacing or sym.format.line_spacing
 
             sym.properties.avoid_edges = self.avoid_edges.value if self.avoid_edges else sym.properties.avoid_edges
-            sym.properties.force_odd_labels = self.force_odd_labels.value if self.force_odd_labels else sym.properties.force_odd_labels
             sym.properties.minimum_distance = self.minimum_distance or sym.properties.minimum_distance
             sym.properties.allow_overlap = self.allow_overlap.value if self.allow_overlap else sym.properties.allow_overlap
 
@@ -429,7 +427,6 @@ class TextSymbolizer:
             sym.line_spacing = self.line_spacing or sym.line_spacing
 
             sym.avoid_edges = self.avoid_edges.value if self.avoid_edges else sym.avoid_edges
-            sym.force_odd_labels = self.force_odd_labels.value if self.force_odd_labels else sym.force_odd_labels
             sym.minimum_distance = self.minimum_distance or sym.minimum_distance
             sym.allow_overlap = self.allow_overlap.value if self.allow_overlap else sym.allow_overlap
         

--- a/cascadenik/style.py
+++ b/cascadenik/style.py
@@ -181,7 +181,6 @@ properties = {
     'text-vertical-align': ('top','middle','bottom',),
     'text-justify-align': ('left','middle','right',),
     'text-transform': ('uppercase','lowercase',),
-    'text-force-odd-labels':boolean,
 
     # Font name
     'text-face-name': strings,

--- a/cascadenik/tests.py
+++ b/cascadenik/tests.py
@@ -2275,7 +2275,6 @@ layer_srs=%(other_srs)s
                 text-dy: 15;
                 text-face-name: 'Helvetica';
                 text-fill: #f00;
-                text-force-odd-labels: true;
                 text-halo-fill: #ff0;
                 text-halo-radius: 2;
                 text-label-position-tolerance: 25;
@@ -2315,7 +2314,6 @@ layer_srs=%(other_srs)s
         self.assertEqual('Helvetica', sym.format.face_name if (MAPNIK_VERSION >= 200100) else sym.face_name)
         self.assertEqual(mapnik.Color("#f00"), sym.format.fill if (MAPNIK_VERSION >= 200100) else sym.fill)
         
-        self.assertEqual(True, sym.properties.force_odd_labels if (MAPNIK_VERSION >= 200100) else sym.force_odd_labels)
         self.assertEqual(mapnik.justify_alignment.LEFT, sym.properties.justify_alignment if (MAPNIK_VERSION >= 200100) else sym.justify_alignment)
         self.assertEqual(mapnik.Color("#ff0"), sym.format.halo_fill if (MAPNIK_VERSION >= 200100) else sym.halo_fill)
         self.assertEqual(2, sym.format.halo_radius if (MAPNIK_VERSION >= 200100) else sym.halo_radius)


### PR DESCRIPTION
mapnik/mapnik#2120 removed `force_odd_labels`, which may have never worked (according to comments in that issue).  When used with recent `mapnik-2.3` nightlies, Cascadenik fails with the following error:

```
Traceback (most recent call last):
  File "/usr/local/bin/cascadenik-compile.py", line 100, in <module>
    sys.exit(main(layersfile, outputfile, **options.__dict__))
  File "/usr/local/bin/cascadenik-compile.py", line 33, in main
    cascadenik.load_map(mmap, src_file, dirname(realpath(dest_file)), **load_kwargs)
  File "/usr/local/lib/python2.7/dist-packages/cascadenik/__init__.py", line 90, in load_map
    compile(src_file, dirs, verbose, datasources_cfg=datasources_cfg, user_styles=user_styles, scale=scale).to_mapnik(map, dirs)
  File "/usr/local/lib/python2.7/dist-packages/cascadenik/output.py", line 74, in to_mapnik
    sym = symbolizer.to_mapnik(fontsets)
  File "/usr/local/lib/python2.7/dist-packages/cascadenik/output.py", line 396, in to_mapnik
    sym.properties.force_odd_labels = self.force_odd_labels.value if self.force_odd_labels else sym.properties.force_odd_labels
AttributeError: 'TextSymbolizerProperties' object has no attribute 'force_odd_labels'
```
